### PR TITLE
allow SwiftDog to be retrieved using Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ DerivedData
 
 Carthage/Build
 
+# Swift Package Manager
+.build
+
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "KeychainAccess",
+        "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess",
+        "state": {
+          "branch": null,
+          "revision": "8d33ffd6f74b3bcfc99af759d4204c6395a3f918",
+          "version": "3.2.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "SwiftDog",
+    platforms: [
+       .iOS(.v8)
+    ],
+    products: [
+        .library(name: "SwiftDog", targets: ["SwiftDog"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess", from: "3.1.0")
+    ],
+    targets: [ .target(name: "SwiftDog", dependencies: ["KeychainAccess"], path: "SwiftDog/Classes") ]
+)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ In order to run this library you need to create a file called `datadog_config.pl
 
 ## Installation
 
+### Swift Package Manager
+
+SwiftDog is availabe through [Swift Package Manager](https://swift.org/package-manager/). To install
+it, simply add `https://github.com/jaronoff97/SwiftDog.git` as a Package Dependency in Xcode by navigating
+to `File -> Swift Packages -> Add Package Dependency...`.
+
+### Carthage
+
 SwiftDog is available through [CocoaPods](https://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 

--- a/SwiftDog/Classes/Datadog.swift
+++ b/SwiftDog/Classes/Datadog.swift
@@ -1,3 +1,5 @@
+import Foundation
+import UIKit
 
 
 public class Datadog: API {

--- a/SwiftDog/Classes/Event.swift
+++ b/SwiftDog/Classes/Event.swift
@@ -5,6 +5,7 @@
 //  Created by jacob.aronoff on 5/4/18.
 //
 
+import Foundation
 
 public struct Event: DataProducer {
     static let event = Event()

--- a/SwiftDog/Classes/IOSAgent.swift
+++ b/SwiftDog/Classes/IOSAgent.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 internal struct DataUsageInfo {
     var wifiReceived: UInt32 = 0

--- a/SwiftDog/Classes/Metric.swift
+++ b/SwiftDog/Classes/Metric.swift
@@ -5,6 +5,7 @@
 //  Created by jacob.aronoff on 5/3/18.
 //
 
+import Foundation
 
 public struct Metric: DataProducer, Encodable {
     

--- a/SwiftDog/Classes/Types.swift
+++ b/SwiftDog/Classes/Types.swift
@@ -5,6 +5,8 @@
 //  Created by jacob.aronoff on 5/3/18.
 //
 
+import Foundation
+
 public typealias DataPoint = (TimeInterval, Float)
 
 public extension Date {


### PR DESCRIPTION
Enables other projects using Swift Package Manager to add SwiftDog to their projects. As a bonus this also allows compilation from the terminal by running `swift build`